### PR TITLE
Add shark-runner command line options for saving modules.

### DIFF
--- a/shark/iree_utils.py
+++ b/shark/iree_utils.py
@@ -15,6 +15,9 @@
 import iree.runtime as ireert
 import iree.compiler as ireec
 import numpy as np
+import tempfile
+import os
+from shark.torch_mlir_utils import get_module_name_for_asm_dump
 
 IREE_DEVICE_MAP = {"cpu": "dylib", "gpu": "cuda", "vulkan": "vulkan"}
 
@@ -32,6 +35,14 @@ def get_iree_compiled_module(module, device: str):
     ModuleCompiled = ctx.modules.module["forward"]
     return ModuleCompiled, config
 
+def export_iree_module_to_vmfb(module, device: str):
+    module_name = get_module_name_for_asm_dump(module)
+    flatbuffer_blob = ireec.compile_str(
+        str(module), target_backends=[IREE_DEVICE_MAP[device]]
+    )
+    filename = os.path.join(tempfile.gettempdir(), module_name + ".vmfb")
+    with open(filename, 'wb') as f:
+        f.write(flatbuffer_blob)
 
 def get_results(compiled_vm, input, config):
     """TODO: Documentation"""

--- a/shark/iree_utils.py
+++ b/shark/iree_utils.py
@@ -15,7 +15,6 @@
 import iree.runtime as ireert
 import iree.compiler as ireec
 import numpy as np
-import tempfile
 import os
 from shark.torch_mlir_utils import get_module_name_for_asm_dump
 
@@ -35,12 +34,12 @@ def get_iree_compiled_module(module, device: str):
     ModuleCompiled = ctx.modules.module["forward"]
     return ModuleCompiled, config
 
-def export_iree_module_to_vmfb(module, device: str):
+def export_iree_module_to_vmfb(module, device: str, directory: str):
     module_name = get_module_name_for_asm_dump(module)
     flatbuffer_blob = ireec.compile_str(
         str(module), target_backends=[IREE_DEVICE_MAP[device]]
     )
-    filename = os.path.join(tempfile.gettempdir(), module_name + ".vmfb")
+    filename = os.path.join(directory, module_name + ".vmfb")
     with open(filename, 'wb') as f:
         f.write(flatbuffer_blob)
 

--- a/shark/shark_runner.py
+++ b/shark/shark_runner.py
@@ -15,7 +15,14 @@
 from shark.torch_mlir_utils import get_torch_mlir_module, export_module_to_mlir_file
 from shark.iree_utils import get_results, get_iree_compiled_module, export_iree_module_to_vmfb
 import argparse
+import os
 # from functorch_utils import AOTModule
+
+def dir_path(path):
+    if os.path.isdir(path):
+        return path
+    else:
+        raise argparse.ArgumentTypeError(f"readable_dir:{path} is not a valid path")
               
 class SharkRunner:
     """TODO: Write the description"""
@@ -30,6 +37,7 @@ class SharkRunner:
         from_aot: bool,
     ):
         self.parser = argparse.ArgumentParser(description='SHARK runner.')
+        self.parser.add_argument("--repro_dir", help="Directory to which module files will be saved for reproduction or debugging.", type=dir_path, default="/tmp/")
         self.parser.add_argument("--save_mlir", default=False, action="store_true", help="Saves input MLIR module to /tmp/ directory.")
         self.parser.add_argument("--save_vmfb", default=False, action="store_true", help="Saves iree .vmfb module to /tmp/ directory.")
         self.parser.parse_args(namespace=self)
@@ -39,9 +47,9 @@ class SharkRunner:
             model, input, dynamic, tracing_required, from_aot
         )
         if self.save_mlir:
-            export_module_to_mlir_file(self.torch_mlir_module)
+            export_module_to_mlir_file(self.torch_mlir_module, self.repro_dir)
         if self.save_vmfb:
-            export_iree_module_to_vmfb(self.torch_mlir_module, device)
+            export_iree_module_to_vmfb(self.torch_mlir_module, device, self.repro_dir)
         (
             self.iree_compilation_module,
             self.iree_config,

--- a/shark/torch_mlir_utils.py
+++ b/shark/torch_mlir_utils.py
@@ -17,7 +17,6 @@ import io
 import pickle
 import sys
 import os
-import tempfile
 
 from io import StringIO
 from torch_mlir.dialects.torch.importer.jit_ir import (
@@ -42,11 +41,11 @@ def get_module_name_for_asm_dump(module):
         return "UnnammedModule"
     return StringAttr(module.operation.attributes["torch.debug_module_name"]).value
     
-def export_module_to_mlir_file(module):
+def export_module_to_mlir_file(module, directory: str):
     """Writes MLIR module to /tmp/module.mlir for debugging or performance use."""
     module_name = get_module_name_for_asm_dump(module)
     asm = module.operation.get_asm()
-    filename = os.path.join(tempfile.gettempdir(), module_name + ".mlir")
+    filename = os.path.join(directory, module_name + ".mlir")
     with open(filename, 'w') as f:
         f.write(asm)
 


### PR DESCRIPTION
Currently supports export of torch-mlir module (as /tmp/[modulename]>.mlir) and iree bytecode module (/tmp/[<modulename].vmfb) via the --save_mlir and --save_vmfb command line flags.

Need to verify that exported modules run correctly through IREE CLI tools before merging.